### PR TITLE
Use 100% over 100vw for side scrolling prevention

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -64,7 +64,7 @@ footer .sponsor-logos-footer a img {
 
 /* Prevent side scrolling */
 #page {
-    width: 100vw;
+    width: 100%;
     overflow-x: hidden;
 }
 


### PR DESCRIPTION
I noticed an issue on the site where a small side-scrolling bar appears for all pages but doesn't really show much more, and there don't seem to be any specific elements that overflow to the right/left. I tweaked with things a bit and found that using `100%` instead of `100vw` removed that unnecessary scrollbar.
