### PR TITLE
Fix speaker twitter handle reference

### DIFF
--- a/program/templates/program/talk.html
+++ b/program/templates/program/talk.html
@@ -70,7 +70,7 @@
       </div>
   {% endif %}
 
-  {% if speaker.twitter %}
+  {% if speaker.twitter_handle %}
     <div class="twitter">
       <a href="https://www.twitter.com/{{ speaker.twitter_handle }}" target="_blank">
         <i class="fa fa-twitter"></i>


### PR DESCRIPTION
The speaker template references the Twitter attribute using the attribute name for organizers, so it never ends up getting displayed. This PR fixes that.
