### PR TITLE
Make sponsor tiers distinct

### DIFF
--- a/sponsors/templates/sponsors/sponsor_logos.html
+++ b/sponsors/templates/sponsors/sponsor_logos.html
@@ -15,3 +15,5 @@
 {% for tier in tiers %}
   {% include "sponsors/sponsor_tier.html" with tiers=tiers %}
 {% endfor %}
+  </div>
+</div>

--- a/sponsors/templatetags/sponsor_tags.py
+++ b/sponsors/templatetags/sponsor_tags.py
@@ -18,12 +18,14 @@ def non_profit_sponsors():
 def corporate_tiers():
     return SponsorTier.objects.filter(
         sponsors__isnull=False, type=SponsorTier.CORPORATE
-    )
+    ).distinct()
 
 
 @register.simple_tag
 def npo_tiers():
-    return SponsorTier.objects.filter(sponsors__isnull=False, type=SponsorTier.NPO)
+    return SponsorTier.objects.filter(
+        sponsors__isnull=False, type=SponsorTier.NPO
+    ).distinct()
 
 
 @register.inclusion_tag("sponsors/sponsor_logos_smol.html")


### PR DESCRIPTION
This fixes an issue where if a tier has more than one sponsor, the entire tier would be duplicated on the page. This was because the `sponsors__isnull=False` filter was causing a join which returned multiple results for the tier query.
