### PR TITLE
Add publishing level sponsorship tier to CSS

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -714,7 +714,8 @@ footer .links li a:hover {
 
 #sponsors .sponsor-logos .item.community .logo,
 #sponsors .sponsor-logos .item.supporting .logo,
-#sponsors .sponsor-logos .item.supporting_npo .logo {
+#sponsors .sponsor-logos .item.supporting_npo .logo,
+#sponsors .sponsor-logos .item.publishing .logo {
     width: 150px;
     height: 90px;
 }
@@ -786,7 +787,8 @@ footer .links li a:hover {
 
     #sponsors .sponsor-logos .item.community .logo,
     #sponsors .sponsor-logos .item.supporting .logo,
-    #sponsors .sponsor-logos .item.supporting_npo .logo {
+    #sponsors .sponsor-logos .item.supporting_npo .logo,
+    #sponsors .sponsor-logos .item.publishing .logo {
         height: 90px;
     }
 


### PR DESCRIPTION
We've added a new tier this year with the slug "publishing". The CSS has some special rules for logos based on certain tiers, and this was causing all logos within non-sanctioned tiers to disappear. This PR adds the publishing tier to the CSS so the logos show up.
