### PR TITLE
Remove "Attend" from navbar

### DIFF
--- a/home/templates/tags/navigation.html
+++ b/home/templates/tags/navigation.html
@@ -22,10 +22,12 @@
       {% endif %}
     {% endfor %}
 
+    <!--- Removed while we don't yet have pretix set up
     <li class="attend">
       <a href="https://pretix.eu/pycascades/remote-2022/" target="_blank">
         Attend
       </a>
     </li>
+    -->
   </ul>
 </nav>


### PR DESCRIPTION
This PR removes the "Attend" link from the navbar of the website.
