### PR TITLE
Add simple folder for new manual Netlify site setup

### DIFF
--- a/_netlify_dev/index.html
+++ b/_netlify_dev/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>PyCascades</title>
+    </head>
+    <body>
+        <p>This is a file which can be used for creating a new Netlify site.</p>
+    </body>
+</html>


### PR DESCRIPTION
This PR adds a simple site which can be used as the first upload for a manually deployed Netlify starter site. This was used for setting up the site for 2023.
