### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+#################################
+# Dependabot Configuration File #
+#################################
+
+# current Github-native version of Dependabot
+version: 2
+
+updates:
+  # Enable version updates for Python libraries in `poetry.lock`
+  - package-ecosystem: pip
+    directory: /
+    # Check for updates once a month
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,6 @@ updates:
     # Check for updates once a month
     schedule:
       interval: monthly
+    open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
This PR adds a dependabot config. We have a number of dependabot alerts presently, this should ensure we remain up-to-date.
