### PR TITLE
Only return banners that are allowed to be shown

### DIFF
--- a/home/templatetags/corner_banner_tags.py
+++ b/home/templatetags/corner_banner_tags.py
@@ -7,6 +7,6 @@ register = template.Library()
 @register.inclusion_tag("tags/corner_banner.html", takes_context=True)
 def corner_banner(context):
     return {
-        "banner": CornerBanner.objects.all().first(),
+        "banner": CornerBanner.objects.filter(show_banner=True).first(),
         "request": context["request"],
     }


### PR DESCRIPTION
Fixes #23

This prevents the corner banner tag from returning a banner which ultimately can't be shown anyway. Tested locally, worked great!
