### PR TITLE
Add a COVID page template

### DIFF
--- a/home/templates/pages/conduct.html
+++ b/home/templates/pages/conduct.html
@@ -3,7 +3,7 @@
 
 {% block content_body %}
 
-<div class="conduct-violations">
+<div class="additional-info">
   <h3>report a violation</h3>
   <ul>
     <li><a href="/about/code-of-conduct-reporting-guide/">Reporting Guide</a>

--- a/home/templates/pages/covid.html
+++ b/home/templates/pages/covid.html
@@ -1,0 +1,14 @@
+{% extends "pages/simple_page.html" %}
+{% load wagtailcore_tags %}
+
+{% block content_body %}
+
+<div class="additional-info">
+  <h3>additional covid info</h3>
+  <ul>
+    <li><a href="/about/covid-faq/">COVID FAQ</a></li>
+  </ul>
+</div>
+
+{{ page.content|richtext }}
+{% endblock %}

--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -792,7 +792,7 @@ footer .links li a:hover {
         height: 90px;
     }
 
-    .conduct-violations {
+    .additional-info {
         float: right;
     }
 }
@@ -824,20 +824,20 @@ body.error #main {
     text-align: center;
 }
 
-.conduct-violations {
+.additional-info {
     border-radius: 10px;
     margin: 0 0 4ex 0;
     border: 1px solid #ddd;
 
 }
-.conduct-violations h3 {
+.additional-info h3 {
     border-top-left-radius: 10px;
     border-top-right-radius: 10px;
     background-color: #ddd;
     padding: 1ex;
 }
 
-.conduct-violations ul {
+.additional-info ul {
     padding-left: 2ex;
 }
 


### PR DESCRIPTION
This PR adds a COVID page template with an "additional info" box on the right with a link to the FAQ. I based this off the code of conduct page, which I also modified so we could share the CSS class for it.