### PR TITLE
Add Mastodon verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
           - --ensure-newline-before-comments
           - --line-length=88
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -4,5 +4,6 @@
 {% block body_class %}home{% endblock %}
 
 {% block content %}
+    {% include 'home/mastodon.html' %}
     {% include 'home/welcome_page.html' %}
 {% endblock content %}

--- a/home/templates/home/mastodon.html
+++ b/home/templates/home/mastodon.html
@@ -1,0 +1,4 @@
+<!-- Section should not be visibile, used to verify Mastodon links -->
+<div style="height: 0px;width: 0px;overflow:hidden;">
+    <a rel="me" href="https://fosstodon.org/@pycascades"></a>
+</div>


### PR DESCRIPTION
This PR adds a section to our site to enable Mastodon verification for our new account: https://fosstodon.org/@pycascades
