### PR TITLE
Update Slack invite URL

### DIFF
--- a/pycascades/settings/base.py
+++ b/pycascades/settings/base.py
@@ -184,7 +184,7 @@ BUILD_DIR = f"{os.getcwd()}/_build"
 # Socials info
 TWITTER_URL = "https://twitter.com/pycascades"
 INSTAGRAM_URL = "https://instagram.com/pycascades"
-SLACK_URL = "https://join.slack.com/t/pycascades/shared_invite/zt-131a11r39-P2BkCVYvlXBplG49lJuXOg"  # noqa: E501
+SLACK_URL = "https://join.slack.com/t/pycascades/shared_invite/zt-1l5libchy-RyQi1Kh0PS8DXCfhxhHZhQ"  # noqa: E501
 GOOGLE_ANALYTICS_ID = "UA-120134614-1"
 
 # Footer data


### PR DESCRIPTION
At some point over the last year, Slack changed the way invite links worked and our old one now no longer functions correctly. I've re-generated a _new_ invite link which is set to never expire. This should fix the issue!

You can test this by opening both links in an in-private/incognito browser window. The old one will ask you to log in with an @pycascades email address, the new one should be friendlier and ask you to provide a number of ways to log in.
