### PR TITLE
Ensure main section text is not cut off

### DIFF
--- a/pycascades/static/css/misc/ff.common.css
+++ b/pycascades/static/css/misc/ff.common.css
@@ -29,7 +29,7 @@
 @media (min-width: 750px) {
     .vcontainer:before {
         /* This is just a hack, needs proper fixing!!! */
-        margin-top: 20vh;
+        margin-top: 10vh;
     }
 }
 

--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -397,7 +397,7 @@ header nav {
 }
 #main section .main {
     position: relative;
-    height: 100vh;
+    min-height: 100vh;
 }
 #main section .main .row {
     text-align: left;

--- a/pycascades/static/css/pycascades/pycascades.venue.css
+++ b/pycascades/static/css/pycascades/pycascades.venue.css
@@ -21,13 +21,13 @@ body.venue #main section .main {
 }
 @media (min-width: 750px) {
     body.venue #main section .main {
-        height: 100vh;
+        min-height: 100vh;
         padding: 0;
     }
 }
 
 body.venue #main #map {
-    min-height: 200px;
+    min-height: 100vh;
 }
 
 body.venue #main #map .overlay {


### PR DESCRIPTION
Resolves #7

This PR makes some CSS tweaks to ensure that the text within sections of main-page derivatives is not cut off. The downside to this is that it may cause the background image to be zoomed in quite a bit depending on how much text there is on the page and how large the viewport is.

I'm no CSS expert though, if there's a better way to structure this I'm open to it :slightly_smiling_face:

**Video example** (may need to be viewed in Chrome):


https://user-images.githubusercontent.com/10214785/211111664-dc656fd9-b314-4036-8c6a-64f34c7046aa.mp4


