### PR TITLE
Make the main container respect z-indices

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -365,6 +365,8 @@ header nav {
 }
 
 #main {
+    z-index: 1;
+    position: relative;
 }
 #main > .container {
     margin-top: 120px;


### PR DESCRIPTION
Fixes #48

Shoutout to @ljpendergrass for the help with this one :) 

Per his explanation:

> Since `#main` and `header` are siblings, this means that `main` is z-indexed below `header` which has z of 10. So all content there would be under the header.

Setting the main position to relative allows it to respect z-index appropriately!
