### PR TITLE
Fix isort dependency by upgrading

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: Run isort to sort imports


### PR DESCRIPTION
This issue describes the issue well: https://github.com/WordPress/openverse/pull/367
