### PR TITLE
Default z-index should actually be 0

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -365,7 +365,7 @@ header nav {
 }
 
 #main {
-    z-index: 1;
+    z-index: 0;
     position: relative;
 }
 #main > .container {


### PR DESCRIPTION
Quick follwo up to #49, it turns out the default z-index should be 0 so that all other z-indices are respected appropriately. This was preventing the links in the footer from being clickable. :sparkles: frontend :sparkles:
