### PR TITLE
Set exact python version in lock file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1221,5 +1221,5 @@ testing = ["Pillow (>=6.0.0,<10.0.0)", "Wand (>=0.6,<1.0)", "mock (>=3.0,<4.0)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "~3.10"
+python-versions = "3.10.4"
 content-hash = "4b303c070deaf8a49afff542f1b8af1c57ed43d424a2d5c7c8b92c84ae9864b2"


### PR DESCRIPTION
This was failing to deploy with:

```
-----> Read Python version from poetry.lock

-----> ~3.10 is not valid, please specify an exact Python version (e.g. 3.8.1 or ==3.8.1) in your pyproject.toml (and thus poetry.lock)

 !     Push rejected, failed to compile Python Poetry app.

 !     Push failed
```

I have no idea what I'm doing! It's set to 3.10.4 in our pyproject.toml so idk why it's different in the lock file.
