### PR TITLE
replace deprecated tile server

### DIFF
--- a/home/templates/home/venue_page.html
+++ b/home/templates/home/venue_page.html
@@ -3,22 +3,26 @@
 {% load wagtailimages_tags %}
 
 {% block extra_js %}
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.4/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin=""/>
-  <script src="https://unpkg.com/leaflet@1.3.4/dist/leaflet.js" integrity="sha512-nMMmRyTVoLYqjP9hrbed9S+FzjZHW5gY1TWCHA5ckwXZBadntCNs8kEqAWdrb9O7rxbCaA4lKTIWjDXZxflOcA==" crossorigin=""></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+  integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+  crossorigin=""/>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+  integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+  crossorigin=""></script>
   <script>var locationCoordinates = [{{ page.location_lat }},{{ page.location_long }}];
   var map = L.map(
       'map', {
           scrollWheelZoom: false,
       }
-  ).setView(locationCoordinates, 16);
+  ).setView(locationCoordinates, 17);
   mapLink = '<a href="http://openstreetmap.org">OpenStreetMap</a>';
 
-  L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}{r}.{ext}', {
-      attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-      subdomains: 'abcd',
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       minZoom: 0,
       maxZoom: 20,
-      ext: 'png'
+      ext: 'png',
+      detectRetina: true,
+      attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
   }).addTo(map);
 
   var mapPopup = L.marker(locationCoordinates).bindPopup(


### PR DESCRIPTION
The tilelayer service we were using went paid-only. This PR replaces it with a free service.
It also updates leafjs and uses higher-res maps if you're viewing on a retina screen 