### PR TITLE
Only use display-block for sponsor logo, not all links

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -723,7 +723,7 @@ footer .links li a:hover {
     height: 90px;
 }
 
-#sponsors .sponsor-logos .item a {
+#sponsors .sponsor-logos .item .logo a {
     display: block;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
Previously, the `#sponsors .sponsor-logos .item a` selector was applying a `display: block` quality to all links within the sponsors snippet. This is the intended effect for the sponsor logos in order to make them clickable links which render on the webpage correctly, however it was also adversely affecting links that were present in the sponsor description. See this example from last year:
![image](https://github.com/pycascades/pycascades-cms/assets/10214785/523ecb54-5a97-493b-a437-6d872160c7f8)


This PR changes the CSS selector to use a more targeted selection and only applies the `display: block` property to the logos themselves. This means links in the description are displayed in-line, as expected:

![image](https://github.com/pycascades/pycascades-cms/assets/10214785/b0bf372f-6c57-4c57-af0b-69ad10cb46ac)

