### PR TITLE
Re-add search to the installed apps

### DIFF
--- a/pycascades/settings/base.py
+++ b/pycascades/settings/base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     "wagtail.contrib.redirects",
     "wagtail.embeds",
     "wagtail.sites",
+    "wagtail.search",
     "wagtail.users",
     "wagtail.snippets",
     "wagtail.documents",


### PR DESCRIPTION
The `wagtail.search` app was removed in #89, along with some search views. While we don't need the views and the page, we _do_ need the app, as we've been running into this issue: https://github.com/wagtail/wagtail/issues/10289


I've tested this locally and I'm able to upload and search for images as expected!
