### PR TITLE
Make media-query sponsor logo height for gold consistent

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -780,7 +780,7 @@ footer .links li a:hover {
     #sponsors .sponsor-logos .item.gold .logo,
     #sponsors .sponsor-logos .item.gold_npo .logo {
         width: 280px;
-        height: 60px;
+        height: 150px;
     }
 
     #sponsors .sponsor-logos .item.silver .logo,


### PR DESCRIPTION
60px doesn't really make sense so this just makes it match the other limits elsewhere in the file.
