### PR TITLE
Give bronze tier logos a height

### DIFF
--- a/pycascades/static/css/pycascades/pycascades.css
+++ b/pycascades/static/css/pycascades/pycascades.css
@@ -715,6 +715,7 @@ footer .links li a:hover {
     height: 90px;
 }
 
+#sponsors .sponsor-logos .item.bronze .logo,
 #sponsors .sponsor-logos .item.community .logo,
 #sponsors .sponsor-logos .item.supporting .logo,
 #sponsors .sponsor-logos .item.supporting_npo .logo,
@@ -788,6 +789,7 @@ footer .links li a:hover {
         height: 90px;
     }
 
+    #sponsors .sponsor-logos .item.bronze .logo,
     #sponsors .sponsor-logos .item.community .logo,
     #sponsors .sponsor-logos .item.supporting .logo,
     #sponsors .sponsor-logos .item.supporting_npo .logo,


### PR DESCRIPTION
Bronze logos aren't showing up because they aren't provided a height as part of the media queries.
